### PR TITLE
Ban Block Breaker

### DIFF
--- a/scripts/hello (1).zs
+++ b/scripts/hello (1).zs
@@ -206,7 +206,8 @@ mods.thaumcraft.Research.addInfusionPage("SILVERWOODINFUSION", <Thaumcraft:block
 //Axe the dagger, altar, and knife recipes.
 
 
-//Remove Block breaker
+//Remove Block Breaker & Terrain Smasher
+recipes.remove(<MineFactoryReloaded:machine.0:7>);
 recipes.remove(<ThermalExpansion:Device:3>);
 
 //Remove metal from Milk


### PR DESCRIPTION
Prevent the block breaker from being crafted, since the terrain smasher gets the same treatment.

Some help with hiding it from NEI? I tried, but couldn't get it to work.