### PR TITLE
HarvestCraft Aspect Fix

### DIFF
--- a/scripts/EssentiaEverything.zs
+++ b/scripts/EssentiaEverything.zs
@@ -143,9 +143,6 @@ mods.thaumcraft.Aspects.set(<TConstruct:Smeltery:6>, "terra 3, ignis 2"); //Sear
 
 mods.thaumcraft.Aspects.set(<TConstruct:decoration.stonetorch>, "lux 1");
 
-mods.thaumcraft.Aspects.set(<harvestcraft:heavycreamItem>, "fames 1, sano 1");
-mods.thaumcraft.Aspects.set(<harvestcraft:butterItem>, "gula 2");
-
 mods.thaumcraft.Aspects.set(<minecraft:milk_bucket>, "sano 2, aqua 2, fames 2");
 
 mods.thaumcraft.Aspects.set(<ThermalFoundation:Storage:12>, "metallum 20, alienis 13, lucrum 13, potentia 7"); //Enderium
@@ -154,12 +151,6 @@ mods.thaumcraft.Aspects.set(<ThermalFoundation:Storage:11>, "metallum 20, machin
 mods.thaumcraft.Aspects.set(<ThermalFoundation:Storage:8>, "metallum 20, machina 7, ordo 7"); //Invar
 mods.thaumcraft.Aspects.set(<ThermalFoundation:Storage:4>, "metallum 7, ordo 14, machina 7"); //Nickel
 mods.thaumcraft.Aspects.set(<RedstoneArsenal:Storage>, "metallum 20, machina 14, lucrum 7"); //Fluxed Electrum
-
-mods.thaumcraft.Aspects.set(<harvestcraft:cheeseItem>, "aqua 1, sano 1, fames 1");
-mods.thaumcraft.Aspects.set(<harvestcraft:doughItem>, "aqua 1, messis 1, fames 1");
-mods.thaumcraft.Aspects.set(<harvestcraft:toastItem>, "fames 2, messis 3, ignis 1");
-mods.thaumcraft.Aspects.set(<harvestcraft:grilledcheeseItem>, "fames 3, messis 2, ignis 1, gula 1, sano 1");
-mods.thaumcraft.Aspects.set(<harvestcraft:taffyItem>, "aqua 1");
 
 mods.thaumcraft.Aspects.set(<appliedenergistics2:item.ItemMultiMaterial:17>, "vitreus 4, lucrum 4");
 mods.thaumcraft.Aspects.set(<appliedenergistics2:item.ItemMultiMaterial:18>, "lucrum 2");

--- a/scripts/HarvestCraftAspectFix.zs
+++ b/scripts/HarvestCraftAspectFix.zs
@@ -1,0 +1,128 @@
+// Note: This list only includes the foods not banned by killHarvestCraft.zs
+// If any entries in it are changed, this file may need to change as well.
+
+print("SCRIPT: HarvestCraft Aspect Fix");
+
+// Jellies
+mods.thaumcraft.Aspects.set(<harvestcraft:applejellyItem>, "fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:blackberryjellyItem>, "fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:blueberryjellyItem>, "fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:raspberryjellyItem>, "fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:watermelonjellyItem>, "fames 2");
+
+// Smoothies
+mods.thaumcraft.Aspects.set(<harvestcraft:blackberrysmoothieItem>, "gelum 1, victus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:blueberrysmoothieItem>, "gelum 1, victus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:melonsmoothieItem>, "gelum 1, victus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:raspberrysmoothieItem>, "gelum 1, victus 1");
+
+// Yogurts
+mods.thaumcraft.Aspects.set(<harvestcraft:appleyogurtItem>, "sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:blackberryyogurtItem>, "sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:blueberryyogurtItem>, "sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:melonyogurtItem>, "sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:plainyogurtItem>, "sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:pumpkinyogurtItem>, "sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:raspberryyogurtItem>, "sano 2, fames 2");
+
+// Juices
+mods.thaumcraft.Aspects.set(<harvestcraft:applejuiceItem>, "aqua 1, victus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:blackberryjuiceItem>, "aqua 1, victus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:blueberryjuiceItem>, "aqua 1, victus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:carrotjuiceItem>, "aqua 1, messis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:melonjuiceItem>, "aqua 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:raspberryjuiceItem>, "aqua 1, victus 1");
+
+// Veggie (Heavy Cream) Soups
+mods.thaumcraft.Aspects.set(<harvestcraft:carrotsoupItem>, "messis 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:cucumbersoupItem>, "messis 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:pumpkinsoupItem>, "messis 1, sano 1");
+
+// Only Stock Soups
+mods.thaumcraft.Aspects.set(<harvestcraft:cactussoupItem>, "messis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:gardensoupItem>, "messis 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:potatosoupItem>, "fames 1, messis 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:seedsoupItem>, "messis 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:vegetablesoupItem>, "messis 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:tomatosoupItem>, "messis 2");
+
+// Complex Soups
+mods.thaumcraft.Aspects.set(<harvestcraft:creamedbroccolisoupItem>, "messis 3");
+mods.thaumcraft.Aspects.set(<harvestcraft:splitpeasoupItem>, "corpus 2, messis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:chickennoodlesoupItem>, "corpus 2, messis 2, fames 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:turnipsoupItem>, "messis 2, gula 1");
+
+// Potatoes
+mods.thaumcraft.Aspects.set(<harvestcraft:scallionbakedpotatoItem>, "sano 1, messis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:butteredpotatoItem>, "sano 1, messis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:loadedbakedpotatoItem>, "sano 2, messis 1, corpus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:mashedpotatoesItem>, "sano 2, messis 1");
+
+// -=- Dough-based foods -=-
+mods.thaumcraft.Aspects.set(<harvestcraft:doughItem>, "aqua 1, messis 1, fames 1");
+
+// Fruit Pies
+mods.thaumcraft.Aspects.set(<harvestcraft:applepieItem>, "aqua 2, messis 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:blueberrypieItem>, "aqua 2, messis 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:raspberrypieItem>, "aqua 2, messis 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:blackberrycobblerItem>, "aqua 2, messis 1, fames 1");
+
+// Cakes
+mods.thaumcraft.Aspects.set(<harvestcraft:cheesecakeItem>, "aqua 1, messis 1, fames 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:pumpkincheesecakeItem>, "aqua 1, messis 2, fames 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:carrotcakeItem>, "aqua 1, messis 2, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:redvelvetcakeItem>, "messis 1, fames 2, sensus 2, sano 2");
+
+// Pasta
+mods.thaumcraft.Aspects.set(<harvestcraft:pastaItem>, "messis 1, fames 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:spagettiItem>, "messis 2, fames 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:spagettiandmeatballsItem>, "messis 2, fames 1, sano 1, corpus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:broccolimacItem>, "messis 2, sano 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:eggplantparmItem>, "messis 3, sano 2, fames 2");
+
+// Donuts
+mods.thaumcraft.Aspects.set(<harvestcraft:donutItem>, "messis 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:frosteddonutItem>, "aqua 1, messis 1, fames 2, sensus 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:powdereddonutItem>, "messis 1, fames 3");
+
+// Other baked goods
+mods.thaumcraft.Aspects.set(<harvestcraft:pancakesItem>, "messis 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:blueberrypancakesItem>, "messis 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:wafflesItem>, "aqua 1, messis 1, sano 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:datenutbreadItem>, "messis 2, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:softpretzelItem>, "aqua 1, messis 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:pumpkinbreadItem>, "messis 2, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:lavendershortbreadItem>, "messis 1, fames 1, sensus 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:potatoandcheesepirogiItem>, "messis 2, fames 2, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:fairybreadItem>, "messis 1, fames 2, sensus 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:damperItem>, "aqua 1, sano 1, messis 1, fames 1");
+
+// Burgers
+mods.thaumcraft.Aspects.set(<harvestcraft:cheeseburgerItem>, "messis 1, corpus 1, sano 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:baconmushroomburgerItem>, "messis 1, corpus 2, sano 1, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:baconcheeseburgerItem>, "messis 1, corpus 2, sano 1, fames 1");
+
+// Other known issues:
+mods.thaumcraft.Aspects.set(<harvestcraft:cheeseItem>, "aqua 1, sano 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:toastItem>, "fames 2, messis 3, ignis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:grilledcheeseItem>, "fames 3, messis 2, ignis 1, gula 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:taffyItem>, "aqua 1, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:butterItem>, "gula 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:heavycreamItem>, "fames 1, sano 1");
+
+mods.thaumcraft.Aspects.set(<harvestcraft:stuffedmushroomItem>, "aqua 1, sano 1, fames 2");
+mods.thaumcraft.Aspects.set(<harvestcraft:steamedpeasItem>, "aqua 1, messis 1");
+
+mods.thaumcraft.Aspects.remove(<harvestcraft:mincepieItem>, "metallum 6");
+mods.thaumcraft.Aspects.remove(<harvestcraft:vegemiteItem>, "metallum 6");
+
+mods.thaumcraft.Aspects.set(<harvestcraft:icecreamItem>, "sano 1, gelum 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:caramelicecreamItem>, "sano 1, gelum 1");
+
+mods.thaumcraft.Aspects.set(<harvestcraft:herbbutterparsnipsItem>, "messis 1, gula 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:chickenparmasanItem>, "corpus 2, sano 1, messis 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:bakedturnipsItem>, "messis 1, gula 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:zucchinifriesItem>, "messis 1, sano 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:pizzaItem>, "corpus 2, sano 1, messis 2, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:chickenpotpieItem>, "corpus 2, messis 3, fames 1");
+mods.thaumcraft.Aspects.set(<harvestcraft:glazedcarrotsItem>, "messis 1, gula 1, fames 1");


### PR DESCRIPTION
Replaces the aspects of every food that would have contained Metallum with more balanced ones.
Also moves all Harvestcraft Aspect Fixes to a single file.