### PR TITLE
Add blightbuster config and fix minetweaker script

### DIFF
--- a/config/archaicfix.cfg
+++ b/config/archaicfix.cfg
@@ -87,7 +87,7 @@ general {
     B:lazyChunkLoading=false
 
     # Log when cascading worldgen occurs. [default: true]
-    B:logCascadingWorldgen=true
+    B:logCascadingWorldgen=false
 
     # Print a stacktrace when cascading worldgen occurs. Use only for development as this will add more lag in game. [default: false]
     B:logCascadingWorldgenStacktrace=false

--- a/config/blightbuster.cfg
+++ b/config/blightbuster.cfg
@@ -1,0 +1,37 @@
+# Configuration file
+
+"dawn machine" {
+    S:"Dawn Machine Corners"=0,0:112,135
+    I:"Dawn Machine radius when not provided with Aer"=4
+    I:"Dawn Machine radius when provided with Aer"=50
+    B:"Use Dawn Machine Corners"=true
+}
+
+
+
+general {
+    B:"Create Thaumcraft Tab"=true
+    B:"Enable Blood Magic Integration"=true
+    B:"Enable Botania Integration"=true
+    B:"Enable Custom NPC Support"=true
+    B:"Enable Dawn Charger"=true
+    B:"Enable Dawn Machine"=true
+    B:"Enable Dawn Offering"=true
+    B:"Enable Dawn Totem"=true
+    B:"Enable Purity Focus"=true
+    B:"Enable RF Integration"=true
+    B:"Enable Silver Potion"=true
+    B:"Enable Super World Tainter"=true
+    B:"Enable Thaumic Energistics Integration"=true
+    B:"Enable World Tainter"=true
+    B:"Register Research"=true
+    S:customNpcMappings=TaintedOcelot:Ozelot,TaintedWolf:Wolf,TaintedTownsfolk:Villager
+    S:purifiedMappings=Thaumcraft.TaintedSheep:Sheep,Thaumcraft.TaintedCow:Cow,Thaumcraft.TaintedChicken:Chicken,Thaumcraft.TaintedPig:Pig,Thaumcraft.TaintedVillager:Villager,Thaumcraft.TaintedCreeper:Creeper
+}
+
+
+purification {
+    S:"Default Biome"=Plains
+}
+
+

--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -2,7 +2,7 @@
 
 asm {
     # Disable CoFH TileEntity cache (and patch MineFactory Reloaded and Thermal Expansion with a workaround) [default: true]
-    B:cofhWorldTransformer=true
+    B:cofhWorldTransformer=false
 
     # Speedup LongInt HashMap [default: true]
     B:speedupLongIntHashMap=true
@@ -78,6 +78,9 @@ fixes {
 
     # Fix losing bonus hearts on dimension change [default: true]
     B:fixDimensionChangeHearts=true
+
+    # Fix duplicate sounds from playing when closing a gui. [default: true]
+    B:fixDuplicateSounds=true
 
     # Fix deleting stack when eating mushroom stew [default: true]
     B:fixEatingStackedStew=true
@@ -493,7 +496,7 @@ speedups {
     B:optimizeTileentityRemoval=true
 
     # Replace reflection in VoxelMap to directly access the fields instead. [default: true]
-    B:replaceVoxelMapReflection=false
+    B:replaceVoxelMapReflection=true
 
     # Speedup biome fog rendering in BiomesOPlenty [default: true]
     B:speedupBOPFogHandling=true
@@ -595,6 +598,9 @@ tweaks {
 
     # Allows blocks to be placed at a faster rate (toggleable via keybind) [default: false]
     B:fastBlockPlacing=false
+
+    # Allow players on your server to use fast block placement [default: true]
+    B:fastBlockPlacingServerSide=true
 
     # Fix Project Red components popping off on unloaded chunks [default: true]
     B:fixComponentsPoppingOff=true

--- a/scripts/Misc. Singletons.zs
+++ b/scripts/Misc. Singletons.zs
@@ -1,4 +1,5 @@
 import mods.nei.NEI;
+import minetweaker.item.IItemStack;
 
 print("SCRIPT: Miscellanous Singletons");
 


### PR DESCRIPTION
Most of these settings were off by default.

Some sane settings for hodgepodge 2.5.36 (2.5.32 is what current rc uses). Enabled voxelmap mixin for java 11+ compat and disabled cofh transformer to combat a rare bug

Fixed ArchaicFix log spam on world gen

Also fix underground biomes stone conjuration by adding IItemStack import