### PR TITLE
EFR Compat Update

### DIFF
--- a/config/AWWayofTime.cfg
+++ b/config/AWWayofTime.cfg
@@ -426,7 +426,7 @@ orecrushing {
         minecraft:glowstone:0
         minecraft:stonebrick:0
         AWWayofTime:largeBloodStoneBrick:0
-        minecraft:beacon:0
+        etfuturum:beacon
         minecraft:stonebrick:0
         AWWayofTime:blockCrystal:0
      >

--- a/config/etfuturum/blocksitems.cfg
+++ b/config/etfuturum/blocksitems.cfg
@@ -173,7 +173,7 @@ equipment {
     # Examples:
     # mods.etfuturum.enchantingFuel.addFuel(<etfuturum:amethyst_shard>); //(Adds amethyst shards as an enchanting fuel)
     # mods.etfuturum.enchantingFuel.remove(<minecraft:dye:4>); //(Removes lapis lazuli as an enchanting fuel) [default: true]
-    B:enableNewEnchantingTable=false
+    B:enableNewEnchantingTable=true
 
     # Enable the old Et Futurum daylight sensor block. Should be enabled if you still have the old Et Futurum copy of the non-inverted daylight detector that need to be converted. [default: false]
     B:enableOldBaseDaylightSensor=false

--- a/scripts/EFRFixes.zs
+++ b/scripts/EFRFixes.zs
@@ -1,0 +1,63 @@
+print("SCRIPT: EFR Fixes");
+
+// Smooth quartz recipe conflict with ExU burnt quartz
+furnace.remove(<etfuturum:smooth_quartz>);
+recipes.addShapeless(<etfuturum:smooth_quartz> * 1, [<minecraft:quartz_block>]);
+
+// Boat seat localization for thaumometer
+game.setLocalization("entity.etfuturum.new_boat_seat.name", "Boat");
+
+// Armor stand localization
+game.setLocalization("entity.etfuturum.wooden_armorstand.name", "Armor Stand");
+game.setLocalization("<etfuturum:wooden_armorstand>", "Armor Stand");
+
+// Add thaumcraft aspects
+// (Chest) boats
+mods.thaumcraft.Aspects.setEntity("etfuturum.new_boat", "aqua 4, iter 4, arbor 3");
+mods.thaumcraft.Aspects.setEntity("etfuturum.chest_boat", "aqua 4, iter 4, vacuos 4, arbor 6");
+mods.thaumcraft.Aspects.set(<etfuturum:bamboo_raft>, "aqua 4, iter 4, arbor 3");
+mods.thaumcraft.Aspects.set(<etfuturum:bamboo_chest_raft>, "aqua 4, iter 4, vacuos 4, arbor 6");
+mods.thaumcraft.Aspects.add(<etfuturum:spruce_chest_boat>, "vacuos 4, arbor 3");
+mods.thaumcraft.Aspects.add(<etfuturum:acacia_chest_boat>, "vacuos 4, arbor 3");
+mods.thaumcraft.Aspects.add(<etfuturum:birch_chest_boat>, "vacuos 4, arbor 3");
+mods.thaumcraft.Aspects.add(<etfuturum:dark_oak_chest_boat>, "vacuos 4, arbor 3");
+mods.thaumcraft.Aspects.add(<etfuturum:jungle_chest_boat>, "vacuos 4, arbor 3");
+mods.thaumcraft.Aspects.add(<etfuturum:oak_chest_boat>, "vacuos 4, arbor 3");
+
+// Beds
+mods.thaumcraft.Aspects.set(<etfuturum:pink_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:light_gray_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:purple_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:green_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:gray_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:orange_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:blue_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:brown_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:white_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:black_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:lime_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:magenta_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:cyan_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:yellow_bed>, "pannus 6, desidia 4, fabrico 3");
+mods.thaumcraft.Aspects.set(<etfuturum:light_blue_bed>, "pannus 6, desidia 4, fabrico 3");
+
+// Other
+mods.thaumcraft.Aspects.add(<etfuturum:observer>, "invidia 2"); // Match comparator
+mods.thaumcraft.Aspects.add(<etfuturum:lantern>, "lux 2");
+mods.thaumcraft.Aspects.add(<etfuturum:composter>, "permutatio 2");
+mods.thaumcraft.Aspects.add(<etfuturum:barrel>, "vacuos 4"); // Match chest
+mods.thaumcraft.Aspects.add(<etfuturum:iron_trapdoor>, "machina 2, motus 1, "); // Match iron door
+mods.thaumcraft.Aspects.set(<etfuturum:end_bricks:*>, "terra 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<etfuturum:coarse_dirt:*>, "terra 2");
+mods.thaumcraft.Aspects.set(<etfuturum:blackstone:*>, "tenebrae 1, terra 1");
+mods.thaumcraft.Aspects.set(<etfuturum:gilded_blackstone>, "lucrum 1, tenebrae 1");
+mods.thaumcraft.Aspects.set(<etfuturum:polished_blackstone_pressure_plate>, "tenebrae 1, machina 1, sensus 1");
+mods.thaumcraft.Aspects.set(<etfuturum:honeycomb>, "ordo 2, fames 1"); // Match Natura
+mods.thaumcraft.Aspects.set(<etfuturum:honey_bottle>, "fames 2, vinculum 1, sano 1");
+mods.thaumcraft.Aspects.set(<etfuturum:honey_block>, "fames 7, vinculum 3, sano 3");
+mods.thaumcraft.Aspects.set(<etfuturum:end_crystal>, "alienis 3, praecantatio 3, sano 3"); // Match entity
+mods.thaumcraft.Aspects.set(<etfuturum:dye:*>, "sensus 1");
+mods.thaumcraft.Aspects.addEntity("etfuturum.wooden_armorstand", "arbor 4, tutamen 1");
+mods.thaumcraft.Aspects.add(<etfuturum:wooden_armorstand>, "tutamen 1");
+mods.thaumcraft.Aspects.add(<etfuturum:banner:*>, "sensus 2");
+

--- a/scripts/EFRFixes.zs
+++ b/scripts/EFRFixes.zs
@@ -4,13 +4,6 @@ print("SCRIPT: EFR Fixes");
 furnace.remove(<etfuturum:smooth_quartz>);
 recipes.addShapeless(<etfuturum:smooth_quartz> * 1, [<minecraft:quartz_block>]);
 
-// Boat seat localization for thaumometer
-game.setLocalization("entity.etfuturum.new_boat_seat.name", "Boat");
-
-// Armor stand localization
-game.setLocalization("entity.etfuturum.wooden_armorstand.name", "Armor Stand");
-game.setLocalization("<etfuturum:wooden_armorstand>", "Armor Stand");
-
 // Add thaumcraft aspects
 // (Chest) boats
 mods.thaumcraft.Aspects.setEntity("etfuturum.new_boat", "aqua 4, iter 4, arbor 3");

--- a/scripts/Localization Issues.zs
+++ b/scripts/Localization Issues.zs
@@ -11,3 +11,13 @@ game.setLocalization("tile.sand.name", "Sand");
 game.setLocalization("Iron Bars.name", "Iron Bars");
 game.setLocalization("Glass Pane.name", "Glass Pane");
 game.setLocalization("tile.sink.name", "Sink");
+
+// Smeltery quartz
+game.setLocalization("en_US", "gui.smeltery.quartz", "Quartz: ");
+
+// Boat seat localization for thaumometer
+game.setLocalization("entity.etfuturum.new_boat_seat.name", "Boat");
+
+// Armor stand localization
+game.setLocalization("entity.etfuturum.wooden_armorstand.name", "Armor Stand");
+game.setLocalization("<etfuturum:wooden_armorstand>", "Armor Stand");

--- a/scripts/Misc. Singletons.zs
+++ b/scripts/Misc. Singletons.zs
@@ -164,6 +164,3 @@ for stone in stones {
 
 // Pulverize Phosphorus
 mods.thermalexpansion.Pulverizer.addRecipe(4000, <Metallurgy:utility.ore:1>, <Metallurgy:utility.item:1> * 2);
-
-// Smeltery Quartz
-game.setLocalization("en_US", "gui.smeltery.quartz", "Quartz: ");

--- a/scripts/Misc. Singletons.zs
+++ b/scripts/Misc. Singletons.zs
@@ -164,3 +164,6 @@ for stone in stones {
 
 // Pulverize Phosphorus
 mods.thermalexpansion.Pulverizer.addRecipe(4000, <Metallurgy:utility.ore:1>, <Metallurgy:utility.item:1> * 2);
+
+// Smeltery Quartz
+game.setLocalization("en_US", "gui.smeltery.quartz", "Quartz: ");


### PR DESCRIPTION
- **Added EFRFixes.zs, which improves compatibility between Thaumcraft 4 and Et Futurum Requiem.**
- **Change the block required for the tier 5 blood altar to the EFR beacon.**
- **Enable the EFR enchantment table, as the ExU division sigil activation works with it.**
- **Add localization for molten nether quartz in the smeltery.**
- **Moved localization fixes to another file.**
