### PR TITLE
Add a recipe for wooden swords to make wooden spikes craftable.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 release/
+/.idea/

--- a/scripts/Blood Magic Tools.zs
+++ b/scripts/Blood Magic Tools.zs
@@ -1,20 +1,26 @@
 print("SCRIPT: Blood Magic Tools");
 
-//Add Alchemical chemistry set recipe to create Diamond Tools using Blood Magic
+// Add Alchemical chemistry set recipes to create vanilla tools with Blood Magic for crafting purposes.
+// Diamond
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:diamond_sword>, [<minecraft:stick>, <TConstruct:swordBlade:1>, <minecraft:diamond>, <minecraft:diamond>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:diamond_pickaxe>, [<minecraft:stick>, <TConstruct:pickaxeHead:1>, <minecraft:diamond>, <minecraft:diamond>, <minecraft:diamond>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:diamond_axe>, [<minecraft:stick>, <TConstruct:hatchetHead:1>, <minecraft:diamond>, <minecraft:diamond>, <minecraft:diamond>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:diamond_shovel>, [<minecraft:stick>, <TConstruct:shovelHead:1>, <minecraft:diamond>], 3, 2000);
 
+// Gold
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:golden_sword>, [<minecraft:stick>, <TConstruct:swordBlade:1>, <minecraft:gold_ingot>, <minecraft:gold_ingot>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:golden_pickaxe>, [<minecraft:stick>, <TConstruct:pickaxeHead:1>, <minecraft:gold_ingot>, <minecraft:gold_ingot>, <minecraft:gold_ingot>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:golden_axe>, [<minecraft:stick>, <TConstruct:hatchetHead:1>, <minecraft:gold_ingot>, <minecraft:gold_ingot>, <minecraft:gold_ingot>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:golden_shovel>, [<minecraft:stick>, <TConstruct:shovelHead:1>, <minecraft:gold_ingot>], 3, 2000);
 
+// Iron
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:iron_sword>, [<minecraft:stick>, <TConstruct:swordBlade:1>, <minecraft:iron_ingot>, <minecraft:iron_ingot>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:iron_pickaxe>, [<minecraft:stick>, <TConstruct:pickaxeHead:1>, <minecraft:iron_ingot>, <minecraft:iron_ingot>, <minecraft:iron_ingot>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:iron_axe>, [<minecraft:stick>, <TConstruct:hatchetHead:1>, <minecraft:iron_ingot>, <minecraft:iron_ingot>, <minecraft:iron_ingot>], 3, 2000);
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:iron_shovel>, [<minecraft:stick>, <TConstruct:shovelHead:1>, <minecraft:iron_ingot>], 3, 2000);
 
-//Add Alchemical chemistry set recipe to create Stone Swords using Blood Magic
+// Stone Swords (for Runed Obsidian (Skull))
 mods.bloodmagic.Alchemy.addRecipe(<minecraft:stone_sword>, [<minecraft:stick>, <TConstruct:swordBlade:1>, <minecraft:cobblestone>, <minecraft:cobblestone>], 3, 2000);
+
+// Wooden Swords (for ExU Wooden Spikes)
+mods.bloodmagic.Alchemy.addRecipe(<minecraft:wooden_sword>, [<minecraft:stick>, <TConstruct:swordBlade:0>, <minecraft:planks:*>, <minecraft:planks:*>], 3, 2000);


### PR DESCRIPTION
Add a recipe for wooden swords to make wooden spikes craftable since the diamond/gold spike bug was fixed.