### PR TITLE
Conceal researches

### DIFF
--- a/scripts/Blightbuster Research.zs
+++ b/scripts/Blightbuster Research.zs
@@ -63,6 +63,7 @@ mods.thaumcraft.Infusion.addRecipe("DAWNOFFERING", <minecraft:obsidian>, [<Trans
 mods.thaumcraft.Research.addPage("DAWNOFFERING", "tc.research_page.DAWNOFFERING.1");
 mods.thaumcraft.Research.addInfusionPage("DAWNOFFERING", <blightbuster:tile.blightbuster_offering>);
 mods.thaumcraft.Research.addPrereq("DAWNOFFERING", "DAWNMACHINE", false);
+mods.thaumcraft.Research.setConcealed("DAWNOFFERING", true);
 
 // Dawn Machine Research
 

--- a/scripts/ChickenChunks.zs
+++ b/scripts/ChickenChunks.zs
@@ -4,6 +4,7 @@ recipes.remove(<ChickenChunks:chickenChunkLoader>);
 recipes.remove(<ChickenChunks:chickenChunkLoader:1>);
 
 mods.thaumcraft.Research.addResearch("CHICKENCHUNKS", "ARTIFICE", "ordo 5, perditio 5, alienis 5, vacuos 5, desidia 5", -4, 9, 4, <ChickenChunks:chickenChunkLoader>);
+mods.thaumcraft.Research.setConcealed("CHICKENCHUNKS", true);
 
 game.setLocalization("en_US", "tc.research_name.CHICKENCHUNKS", "Chunk Loader");
 game.setLocalization("en_US", "tc.research_text.CHICKENCHUNKS", "It's hard not to break the fourth wall here...");

--- a/scripts/EFRFixes.zs
+++ b/scripts/EFRFixes.zs
@@ -58,6 +58,7 @@ mods.thaumcraft.Crucible.addRecipe("BLACKSTONE", <etfuturum:gilded_blackstone>, 
 
 game.setLocalization("en_US", "tc.research_page.BLACKSTONE.1", 'You have seen visions from what you can only assume is a time far removed from your own. These visions have shown you large structures in the Nether inhabited by brutish pig-man hybrids who are obsessed with gold. These "bastions" were composed of dark stone blocks, which have particularly piqued your interest for their decorative potential. Using the same principle as arcane stone, exposing some mundane blackstone cobble to the energy emitted by an order shard allows you to fabricate some of those blocks.');
 game.setLocalization("en_US", "tc.research_page.BLACKSTONE.2", "You can create a block of gilded blackstone by exposing any of these blackstone blocks to lucrum essentia in a crucible. This block seemed to be highly prized by those creatures in your visions.");
+
 mods.thaumcraft.Research.addPage("BLACKSTONE", "tc.research_page.BLACKSTONE.1");
 mods.thaumcraft.Research.addArcanePage("BLACKSTONE", <etfuturum:blackstone:0>);
 mods.thaumcraft.Research.addCraftingPage("BLACKSTONE", <etfuturum:blackstone:1>);
@@ -68,30 +69,37 @@ mods.thaumcraft.Research.addCraftingPage("BLACKSTONE", <etfuturum:blackstone_wal
 mods.thaumcraft.Research.addCraftingPage("BLACKSTONE", <etfuturum:blackstone_wall:2>);
 mods.thaumcraft.Research.addPage("BLACKSTONE", "tc.research_page.BLACKSTONE.2");
 mods.thaumcraft.Research.addCruciblePage("BLACKSTONE", <etfuturum:gilded_blackstone>);
+
 mods.thaumcraft.Research.addPrereq("BLACKSTONE", "ARCANESTONE", false);
 
 // Elytra
-mods.thaumcraft.Research.addResearch("ELYTRA", "ARTIFICE", "volatus 4, motus 4, alienis 3, tutamen 0, praecantatio 0", 2, 6, 5, <etfuturum:elytra>);
-game.setLocalization("en_US", "tc.research_name.ELYTRA", "Elytra");
-game.setLocalization("en_US", "tc.research_text.ELYTRA", "Stick a feather in your cap");
+mods.thaumcraft.Research.addResearch("ELYTRA", "ARTIFICE", "volatus 4, motus 4, alienis 3, tutamen 0, praecantatio 0", 3, 6, 5, <etfuturum:elytra>);
+
+game.setLocalization("en_US", "tc.research_name.ELYTRA", "Elytra Wingsuits");
+game.setLocalization("en_US", "tc.research_text.ELYTRA", "Bring a water bucket to break your fall");
 game.setLocalization("en_US", "tc.research_page.ELYTRA.1", 'While the thaumostatic harness certainly does its job in allowing you to fly, it lacks a certain... grace to its movements. Dragons and bats are able to cut through the air with ease, but you lack the wings that they have. That is, until today. By adding feathers, leather, and air shards to a belt and infusing it with essentia to aid in mobility and emulate the great Ender Dragon, you have created a piece of equipment that you have dubbed "Elytra".');
 game.setLocalization("en_US", "tc.research_page.ELYTRA.2", "While equipped on your body or wings slot, you are able to deploy the wings behind you by jumping in midair. Unlike the mighty dragon or even the lowly bat, you are unable to flap your wings to gain velocity while flying. However, these wings allow gliding over long distances and performing deft acrobatic maneuvers with your momentum while in flight.");
 game.setLocalization("en_US", "tc.research_page.ELYTRA.3", "While you may be unable to flap your wings to gain speed, it is possible to launch yourself a great distance through the use of firework rockets. Despite defying all reason, firework rockets containing explosive charges seem to not damage the user. Caution must be taken to land gently, or a hasty thaumaturge will meet his end due to the kinetic forces exerted upon his body.");
 game.setLocalization("en_US", "tc.research_page.ELYTRA.4", "The elytra will slowly take damage while in flight. This can be mitigated by the Unbreaking enchantment, which can be applied by an anvil or through infusion enchanting. Other means of enchanting, such as the enchantment table, seem to be unable to operate upon the elytra. Damaged elytra may be repaired with leather in an anvil or through other, more magical means.");
+
 mods.thaumcraft.Infusion.addRecipe("ELYTRA", <Thaumcraft:ItemGirdleHover>, [<minecraft:feather>, <minecraft:leather>, <minecraft:ender_eye>, <minecraft:leather>, <Thaumcraft:ItemShard:0>, <minecraft:feather>, <minecraft:leather>, <minecraft:ender_eye>, <minecraft:leather>, <Thaumcraft:ItemShard:0>], "volatus 64, iter 32, aer 32, alienis 16", <etfuturum:elytra>, 7);
 mods.thaumcraft.Research.addPage("ELYTRA", "tc.research_page.ELYTRA.1");
 mods.thaumcraft.Research.addInfusionPage("ELYTRA", <etfuturum:elytra>);
 mods.thaumcraft.Research.addPage("ELYTRA", "tc.research_page.ELYTRA.2");
 mods.thaumcraft.Research.addPage("ELYTRA", "tc.research_page.ELYTRA.3");
 mods.thaumcraft.Research.addPage("ELYTRA", "tc.research_page.ELYTRA.4");
+
 mods.thaumcraft.Research.addPrereq("ELYTRA", "HOVERGIRDLE", false);
+mods.thaumcraft.Research.setConcealed("ELYTRA", true);
 
 // Chorus Flowers
-mods.thaumcraft.Research.addResearch("CHORUSFLOWER", "ARTIFICE", "sensus 3, herba 3, alienis 3, victus 3, iter 0", 3, 6, 5, <etfuturum:chorus_flower>);
+mods.thaumcraft.Research.addResearch("CHORUSFLOWER", "ARTIFICE", "sensus 3, herba 3, alienis 3, victus 3, iter 0", 4, 6, 5, <etfuturum:chorus_flower>);
+
 game.setLocalization("en_US", "tc.research_name.CHORUSFLOWER", "Chorus Flowers");
 game.setLocalization("en_US", "tc.research_text.CHORUSFLOWER", "Houdini's favorite snack");
 game.setLocalization("en_US", "tc.research_page.CHORUSFLOWER.1", 'Your use of alienis to create wings has caused you to wonder about its effects on other forms of life. Taking some sugar cane and infusing it with the essence of the end has left you with quite a strange specimen. This "chorus flower" only seems to grow on end stone, and it will slowly grow upwards, occasionally splitting into multiple thin branches. Much like the sugar cane it is made from, breaking the base will fell the whole chorus plant, but any chorus flowers will be lost. They must be harvested by hand or dislodged by a well-aimed arrow. Flowers that have reached their maximum height will darken.');
 game.setLocalization("en_US", "tc.research_page.CHORUSFLOWER.2", 'When broken, the body of a chorus plant will often drop alien-looking "chorus fruits". These fruits give off a kind of energy that you have only seen left behind after an enderman teleports. Smelting them in a furnace hardens their soft flesh, removing any nutritional value, but this rigidity allows for them to be shaped into eye-catching purple bricks. Additionally, attaching a popped chorus fruit to the end of a blaze rod appears to cause it to continuously emit light, just like a torch.');
+
 mods.thaumcraft.Infusion.addRecipe("CHORUSFLOWER", <minecraft:reeds>, [<minecraft:ender_pearl>,  <minecraft:end_stone>], "sensus 8, herba 8, alienis 8, victus 8, iter 8", <etfuturum:chorus_flower>, 2);
 mods.thaumcraft.Research.addPage("CHORUSFLOWER", "tc.research_page.CHORUSFLOWER.1");
 mods.thaumcraft.Research.addInfusionPage("CHORUSFLOWER", <etfuturum:chorus_flower>);
@@ -101,7 +109,9 @@ mods.thaumcraft.Research.addCraftingPage("CHORUSFLOWER", <etfuturum:purpur_slab>
 mods.thaumcraft.Research.addCraftingPage("CHORUSFLOWER", <etfuturum:purpur_pillar>);
 mods.thaumcraft.Research.addCraftingPage("CHORUSFLOWER", <etfuturum:purpur_stairs>);
 mods.thaumcraft.Research.addCraftingPage("CHORUSFLOWER", <etfuturum:end_rod>);
+
 mods.thaumcraft.Research.addPrereq("CHORUSFLOWER", "ELYTRA", false);
+mods.thaumcraft.Research.setConcealed("CHORUSFLOWER", true);
 
 // Trapdoors
 recipes.remove(<betterstorage:locker>);

--- a/scripts/Extrautils Wings.zs
+++ b/scripts/Extrautils Wings.zs
@@ -9,6 +9,9 @@ recipes.remove(<ExtraUtilities:angelRing:3>);
 recipes.remove(<ExtraUtilities:angelRing:4>);
 
 mods.thaumcraft.Research.addResearch("ANGELRING", "ARTIFICE", "volatus 8, aer 8, ordo 8, fabrico 8", -6, 8, 4, <TabulaRasa:RasaItem0:21>);
+mods.thaumcraft.Research.addPrereq("ANGELRING", "INFUSION", false);
+mods.thaumcraft.Research.setConcealed("ANGELRING", true);
+
 game.setLocalization("en_US", "tc.research_name.ANGELRING", "Angel Rings");
 game.setLocalization("en_US", "tc.research_text.ANGELRING", "More simple than jetpacks");
 game.setLocalization("en_US", "cavestokingdoms.research_page.ANGELRING", "Flight is important, and a thaumostatic harness is great, but there comes a time where you want to jettison the bulky thaumic apparatus and fly in a more natural way.<BR>You decided to create a ring with flight capabilties. Simply having this ring in your inventory will grant you the ability to fly, as if you were in creative mode.<BR>This ring comes in five varieties. They differ only cosmetically.");
@@ -24,5 +27,3 @@ mods.thaumcraft.Research.addInfusionPage("ANGELRING", <ExtraUtilities:angelRing:
 mods.thaumcraft.Research.addInfusionPage("ANGELRING", <ExtraUtilities:angelRing:3>);
 mods.thaumcraft.Research.addInfusionPage("ANGELRING", <ExtraUtilities:angelRing:4>);
 mods.thaumcraft.Research.addInfusionPage("ANGELRING", <ExtraUtilities:angelRing:0>);
-
-mods.thaumcraft.Research.addPrereq("ANGELRING", "INFUSION", false);

--- a/scripts/MetalsAreAnnoying2.zs
+++ b/scripts/MetalsAreAnnoying2.zs
@@ -546,6 +546,7 @@ game.setLocalization("en_US", "tc.research_text.TRANSDIAMOND", "Transformation o
 game.setLocalization("en_US", "tc.research_page.TRANSDIAMOND.1", "You have discovered a way to multiply diamonds by steeping diamond nuggets in lucrum harvested from other substances.");
 mods.thaumcraft.Research.addResearch("TRANSDIAMOND", "FORBIDDEN", "vitreus 4, lucrum 4", 2, -6, 0, <Translocator:diamondNugget>);
 mods.thaumcraft.Research.setSecondary("TRANSDIAMOND", true);
+mods.thaumcraft.Research.setConcealed("TRANSDIAMOND", true);
 mods.thaumcraft.Research.addPrereq("TRANSDIAMOND", "TRANSEMERALD", false);
 mods.thaumcraft.Crucible.addRecipe("TRANSDIAMOND", <Translocator:diamondNugget> * 4, <ore:nuggetDiamond>, "vitreus 2, lucrum 2");
 mods.thaumcraft.Research.addPage("TRANSDIAMOND", "tc.research_page.TRANSDIAMOND.1");

--- a/scripts/TiC and ExtraTiC.zs
+++ b/scripts/TiC and ExtraTiC.zs
@@ -275,6 +275,8 @@ recipes.remove(<TConstruct:materials:6>);
 
 mods.thaumcraft.Research.addResearch("LIVINGMOSS", "ARTIFICE", "instrumentum 4, fabrico 4, limus 4, herba 4, sano 4, victus 4", -8, 5, 4, <TConstruct:materials:6>);
 mods.thaumcraft.Research.addPrereq("LIVINGMOSS", "INFUSION", false);
+mods.thaumcraft.Research.setConcealed("LIVINGMOSS", true);
+
 game.setLocalization("en_US", "tc.research_name.LIVINGMOSS", "Livingmoss");
 game.setLocalization("en_US", "tc.research_text.LIVINGMOSS", "Self-repairing tools");
 game.setLocalization("en_US", "cavestokingdoms.research_page.LIVINGMOSS", "This planet seems different. The moss balls you were trained to craft on homeworld don't work, probably due to changes in the atmosphere. You'll need to find another way.<BR>This plant, called 'Livingmoss', is a magical attempt to recreate the balls of moss that homeworld used. Like classic balls of moss, applying these to modular tools will cause them to self-repair. The rate of repair increases if the moss is exposed to sunlight. This costs no mana, nor essentia, nor life essence, nor RF, nor will it drive you insane. It is, however, slower than many other methods of repairing tools.");

--- a/scripts/hello (1).zs
+++ b/scripts/hello (1).zs
@@ -93,7 +93,10 @@ mods.thaumcraft.Infusion.addRecipe("SILVERWOODINFUSION", <minecraft:sapling>, [<
 // AS+ Helm Infusion
 recipes.remove(<ArchimedesShipsPlus:marker>);
 mods.thaumcraft.Research.addResearch("FLYINGSHIP", "ARTIFICE", "machina 6, potentia 6, iter 6, motus 6, volatus 6", -6, 2, 4, <ArchimedesShipsPlus:marker>);
+
 mods.thaumcraft.Research.addPrereq("FLYINGSHIP", "INFUSION", false);
+mods.thaumcraft.Research.setConcealed("FLYINGSHIP", true);
+
 game.setLocalization("en_US", "tc.research_name.FLYINGSHIP", "Flying Ships");
 game.setLocalization("en_US", "tc.research_text.FLYINGSHIP", "Scouting in Style");
 game.setLocalization("en_US", "cavestokingdoms.research_page.FLYINGSHIP", "The Jaded expects you to scout, and yet they keep all the aircraft for themselves. Hardly seems fair. <BR>Whatever. You can just make your own aircraft. The Ship Helm allows you to create ships. It is the core of the 'Archimedes Ships' mod. Search the internet for more information on how to use that mod; only the recipe for the ship helm has changed.");


### PR DESCRIPTION
Conceal researches that should have been concealed originally. Dawn Machine research is left unconcealed (its shadow is visible without any prereqs researched) because it is very important for the pack. All of the other added research in the pack should be concealed.
Also rename the elytra research name and tagline because I have mc movie brainrot.