### PR TITLE
Let players see recipes for all items

### DIFF
--- a/config/tcneiadditions.cfg
+++ b/config/tcneiadditions.cfg
@@ -11,7 +11,7 @@ general {
     B:showInstabilityNumber=true
 
     # Show recipes even if the research is not completed
-    B:showLockedRecipes=false
+    B:showLockedRecipes=true
 
     # Show research key
     B:showResearchKey=true


### PR DESCRIPTION
They can just open a creative test world to see recipes of items anyway, and the missing research UI has improved significantly with recent updates.