### PR TITLE
Hodgepodge config fixes

### DIFF
--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -795,7 +795,7 @@ speedups {
 
 tweaks {
     # Add CV support to Thaumcraft wand recharge pedestal [default: true]
-    B:addCVSupportToWandPedestal=true
+    B:addCVSupportToWandPedestal=false
 
     # Adds a search bar to the mod config GUI [default: true]
     B:addModConfigSearchBar=true

--- a/config/hodgepodge.cfg
+++ b/config/hodgepodge.cfg
@@ -1085,7 +1085,7 @@ tweaks {
     B:thirstyTankContainer=true
 
     # Enable threaded saving for WorldData [default: true]
-    B:threadedWorldDataSaving=true
+    B:threadedWorldDataSaving=false
 
     # Doesn't render the black box behind messages when the chat is closed [default: true]
     B:transparentChat=true


### PR DESCRIPTION
Disable threaded world saving and wand recharge config

Threaded world saving being disabled fixes the crash when `join a world, then try to create a world`

The wand change is a work around for https://github.com/rndmorris/Salis-Arcana/issues/379