### PR TITLE
Disable mod update checks

### DIFF
--- a/config/AppliedEnergistics2/VersionChecker.cfg
+++ b/config/AppliedEnergistics2/VersionChecker.cfg
@@ -24,7 +24,7 @@ client {
 
 general {
     # If true, the version checker is enabled. Acts as a master switch. [default: true]
-    B:enabled=true
+    B:enabled=false
 }
 
 

--- a/config/BiblioCraft.cfg
+++ b/config/BiblioCraft.cfg
@@ -96,7 +96,7 @@ general {
     B:ChairRedstone=true
 
     # Setting this to false will permanently disable update checking
-    B:CheckForUpdates=true
+    B:CheckForUpdates=false
 
     # Setting this to true will disable all renderers. This will allow a world to be loaded and a problem item removed from a BiblioCraft block in case of a rendering related crash.
     B:DisableRenderers=false

--- a/config/ChickenChunks.cfg
+++ b/config/ChickenChunks.cfg
@@ -28,7 +28,7 @@ allowchunkviewer
 #The number of minutes since last login within which chunks from a player will remain active, 0 for infinite.
 awayTimeout=0
 
-checkUpdates=true
+checkUpdates=false
 
 #The number of ticks to wait between attempting to unload orphaned chunks
 cleanuptime=0

--- a/config/CodeChickenCore.cfg
+++ b/config/CodeChickenCore.cfg
@@ -3,7 +3,7 @@
 #The most recent notification number recieved. -1 to disable
 checkNotifications=0
 
-checkUpdates=true
+checkUpdates=false
 
 #set to true to completely deobfuscate mcp names
 dev.deobfuscate=false

--- a/config/INpureProjects/INpureCore/INpureCore.cfg
+++ b/config/INpureProjects/INpureCore/INpureCore.cfg
@@ -25,7 +25,7 @@ tweaks {
 
 
 updater {
-    B:check=true
+    B:check=false
 }
 
 

--- a/config/Translocator.cfg
+++ b/config/Translocator.cfg
@@ -2,7 +2,7 @@
 #Deleting any element will restore it to it's default value
 #Block ID's will be automatically generated the first time it's run
 
-checkUpdates=true
+checkUpdates=false
 
 #Set to true to disable placement of crafting grids by keyboard shortcut.
 disable-crafting-grid-key=false

--- a/config/bspkrsCore.cfg
+++ b/config/bspkrsCore.cfg
@@ -9,7 +9,7 @@
 
 general {
     # Set to true to allow checking for updates for ALL of my mods, false to disable. [default: true]
-    B:allowUpdateCheck=true
+    B:allowUpdateCheck=false
 
     # The timeout in milliseconds for the version update check. [range: 100 ~ 30000, default: 3000]
     I:updateTimeoutMilliseconds=3000


### PR DESCRIPTION
Doubtful that many of these are getting updates from their original source, or the URL has expired and could be taken by a bad actor. Likely speeds up loading time too